### PR TITLE
modified Return to homepage link with replace to fix Production bug

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -27,6 +27,7 @@ export default function NotFound() {
             href="/" 
             className="not-found-button"
             aria-label="Return to homepage"
+            replace
           >
             Return Home
           </Link>


### PR DESCRIPTION
Currently in Prod, the URL will change when you click Return Home, but the not found layout remains. So, fixing that bug.